### PR TITLE
Fix metadata in pypi package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include package.json
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,12 @@ with open('package.json') as f:
 with open('README.md') as f:
     long_description = f.read()
 
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
 setuptools.setup(
     name='pypi-register',
-    install_requires=open('requirements.txt').read().splitlines(),
+    install_requires=requirements,
     scripts=['scripts/pypi-register'],
     version=package_metadata['version'],
     description=package_metadata['description'],

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,22 @@
 import setuptools
+import json
+
+with open('package.json') as f:
+    package_metadata = json.load(f)
+
+with open('README.md') as f:
+    long_description = f.read()
 
 setuptools.setup(
     name='pypi-register',
     install_requires=open('requirements.txt').read().splitlines(),
     packages=setuptools.find_packages(),
-    scripts=['scripts/pypi-register']
+    scripts=['scripts/pypi-register'],
+    version=package_metadata['version'],
+    description=package_metadata['description'],
+    keywords=package_metadata['keywords'],
+    url=package_metadata['homepage'],
+    license=package_metadata['license'],
+    long_description=long_description,
+    long_description_content_type='text/markdown',
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ with open('README.md') as f:
 setuptools.setup(
     name='pypi-register',
     install_requires=open('requirements.txt').read().splitlines(),
-    packages=setuptools.find_packages(),
     scripts=['scripts/pypi-register'],
     version=package_metadata['version'],
     description=package_metadata['description'],


### PR DESCRIPTION
Hi,

I noticed that pip installs this package as version `0.0.0`:

```python
$ pip install pypi-register
$ pip list | grep pypi-register
pypi-register     0.0.0
```

This is because the uploaded archive is a *source* distribution that executes `setup.py` -- which doesn't know the version and hence falls back to `0.0.0`. Some tools like [pipx](https://github.com/pipxproject/pipx) refuse to install the package because the installed version doesn't match the version advertised in the archive name/metadata.

I also noticed that distributions created by `python setup.py sdist` were missing `requirements.txt`. I assume you used some other (node based?) build tool? (Just out of curiosity, which one?)

This PR fixes `python setup.py sdist bdist_wheel` to create working uploads.

Changes:

- changed `setup.py` to reuse the metadata from `package.json`
- added `MANIFEST.in` to ensure that both `package.json` and `requirements.txt` are included in the archive
- removed unnecessary `setuptools.find_packages()`

Also, I suggest uploading a wheel to pypi. This makes the installation fully independent of the build system (and even allows you to drop `setup.py` completely from the repo if you prefer to use another build tool).
